### PR TITLE
feat: read and provide request body

### DIFF
--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -77,7 +77,7 @@ func runExec(ctx context.Context) {
 	// Read config
 	logger.Debug("load server configuration")
 	loader := configloader.New()
-	config, err := loader.Load(setupCtx, "")
+	config, err := loader.Load(setupCtx, flagConfigFilePath)
 	if err != nil {
 		logger.Error("failed to load config file: " + err.Error())
 		shutdown(logger, false)

--- a/src/interfaces/executer.go
+++ b/src/interfaces/executer.go
@@ -2,10 +2,16 @@ package interfaces
 
 import (
 	"context"
-
-	"github.com/bdoerfchen/webcmd/src/model/config"
+	"io"
 )
 
 type Executer interface {
-	Execute(ctx context.Context, route config.Route) (result []byte, exitCode int, err error)
+	Execute(ctx context.Context, config ExecConfig) (result []byte, exitCode int, err error)
+}
+
+type ExecConfig struct {
+	Command string            // Command file or name on PATH
+	Args    []string          // Process args
+	Env     map[string]string // Environment variables
+	Stdin   io.Reader         // Stdin stream. Can be nil to use /dev/null
 }

--- a/src/services/configloader/loader.go
+++ b/src/services/configloader/loader.go
@@ -58,8 +58,8 @@ func (l *configLoader) Load(ctx context.Context, path string) (*config.AppConfig
 		}
 
 		// Go over read config and validate
-		var result config.AppConfig
-		result.Server = output.Server
+		result := config.DefaultAppConfig()
+		copier.CopyWithOption(&result.Server, &output.Server, copier.Option{IgnoreEmpty: true})
 		for _, configRoute := range output.Routes {
 			copiedRoute := config.DefaultRoute()
 			copier.CopyWithOption(&copiedRoute, &configRoute, copier.Option{IgnoreEmpty: true})

--- a/src/services/executer/executer.go
+++ b/src/services/executer/executer.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/bdoerfchen/webcmd/src/model/config"
+	"github.com/bdoerfchen/webcmd/src/interfaces"
 )
 
 type executor struct{}
@@ -16,21 +16,22 @@ func New() *executor {
 	return &executor{}
 }
 
-func (e *executor) Execute(ctx context.Context, route config.Route) (result []byte, exitCode int, err error) {
+func (e *executor) Execute(ctx context.Context, config interfaces.ExecConfig) (result []byte, exitCode int, err error) {
 	// Parse command and arguments
-	parts := strings.SplitAfterN(route.Command, " ", 2)
+	parts := strings.SplitAfterN(config.Command, " ", 2)
 	command := strings.TrimSpace(parts[0])
 
 	// Initialize buffer to save command's output in
 	outputBuffer := bytes.NewBuffer(make([]byte, 0))
 
 	// Setup command with stdout buffer
-	cmd := exec.CommandContext(ctx, command, route.Args...)
+	cmd := exec.CommandContext(ctx, command, config.Args...)
 	cmd.Stdout = outputBuffer
 	cmd.Stderr = cmd.Stdout
+	cmd.Stdin = config.Stdin
 
 	// Add environment variables
-	for key, value := range route.Env {
+	for key, value := range config.Env {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
 	}
 


### PR DESCRIPTION
Introduces:
- New route parameter to allow reading the body
- New ExecConfig as input for the interfaces.Executer
- Use request body as exec stdin if allowed

Fixed:
- Config file path is now taken from cli flag

closes #6