### PR TITLE
feat: server header and app version

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,8 @@
             "args": [
                 "run", "-v",
                 "-c", "examples/exec",
-            ]
+            ],
+            "buildFlags": "-buildvcs=true"
         }
     ]
 }

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bdoerfchen/webcmd/src/common/execution"
 	"github.com/bdoerfchen/webcmd/src/common/process"
 	"github.com/bdoerfchen/webcmd/src/common/router"
+	"github.com/bdoerfchen/webcmd/src/common/version"
 	"github.com/bdoerfchen/webcmd/src/logging"
 	"github.com/bdoerfchen/webcmd/src/services/chirouter"
 	"github.com/bdoerfchen/webcmd/src/services/configloader"
@@ -61,6 +62,12 @@ func Start(ctx context.Context) {
 	// Server config flags
 	runCmd.Flags().Uint16VarP(&flagServerPort, "port", "p", 0, "Set the server port")
 	runCmd.Flags().StringVar(&flagServerHost, "host", "", "Set the host IP address to listen to")
+
+	// Configure version command
+	rootCmd.Version = version.Full()
+	if sha, err := version.CommitSha(); err == nil {
+		rootCmd.Version += "-" + sha[:10]
+	}
 
 	rootCmd.AddCommand(runCmd)
 	rootCmd.ExecuteContext(ctx)

--- a/src/common/version/version.go
+++ b/src/common/version/version.go
@@ -1,0 +1,26 @@
+package version
+
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+const MAJOR = "0"
+const MINOR = "1"
+const PATCH = "0"
+
+func Full() string {
+	return fmt.Sprintf("%s.%s.%s", MAJOR, MINOR, PATCH)
+}
+
+func CommitSha() (string, error) {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs.revision" {
+				return setting.Value, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("vcs revision not embedded")
+}

--- a/src/services/chirouter/router.go
+++ b/src/services/chirouter/router.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"runtime"
 	"strings"
 	"time"
 
 	"github.com/bdoerfchen/webcmd/src/common/config"
 	"github.com/bdoerfchen/webcmd/src/common/execution"
+	"github.com/bdoerfchen/webcmd/src/common/version"
 	"github.com/bdoerfchen/webcmd/src/logging"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -119,6 +121,9 @@ func (r *chirouter) addRoute(route config.Route, executor execution.Executer, lo
 		for header, value := range exitResponse.Headers {
 			w.Header().Add(header, value)
 		}
+		// Add Server header
+		serverHeader := fmt.Sprintf("webcmd/%s (%s)", version.Full(), runtime.GOOS)
+		w.Header().Add("Server", serverHeader)
 
 		// Respond with command result and mapped status code from exit code
 		w.WriteHeader(exitResponse.StatusCode)


### PR DESCRIPTION
Features:
- Adding --version flag
- Always respond with "Server" header including the app version and environment

Example:
```
Server: webcmd/0.1.0 (linux)
```

closes #15