### PR TITLE
feat!: fine-grained response stream selection

### DIFF
--- a/examples/streams/server.config.yaml
+++ b/examples/streams/server.config.yaml
@@ -1,0 +1,23 @@
+routes:
+- route: "/exit/{code}"
+  exec:
+    shell:
+      command: "echo STDOUT > /dev/stdout; echo STDERR > /dev/stderr; exit ${WC_CODE-0}"
+  responseStream: none # set the default configuration for the status codes in this route
+  statusCodes:
+  - exitCode: 0
+    statusCode: 200
+    responseStream: stdout
+  - exitCode: 1
+    statusCode: 400
+    responseStream: stderr
+  - exitCode: 2
+    statusCode: 404
+    responseStream: both
+  - statusCode: 500
+    # catches all other exit codes and uses no response stream due to previous configuration
+    
+- route: "/*"
+  exec:
+    shell:
+      command: "echo Use 'GET /exit/{code}' to get different response streams"

--- a/src/cmd/setup.go
+++ b/src/cmd/setup.go
@@ -28,8 +28,8 @@ func mergeCommandFlags(base *config.AppConfig, logger *slog.Logger) {
 	route := config.DefaultRoute()
 	// Define default response code 500
 	route.StatusCodes = append(route.StatusCodes, config.ExitCodeMapping{
-		StatusCode:    http.StatusInternalServerError,
-		ResponseEmpty: true,
+		StatusCode:     http.StatusInternalServerError,
+		ResponseStream: config.None,
 	})
 	routeTouched := false
 

--- a/src/common/config/check.go
+++ b/src/common/config/check.go
@@ -43,9 +43,17 @@ func (r *Route) Check() (result RouteErrorCollection) {
 		}
 	}
 
-	// Check status codes
+	// Check exit codes
+	for _, codeMapping := range r.StatusCodes {
+		// Check for valid response stream names
+		if !codeMapping.ResponseStream.IsValid() {
+			result = append(result, RouteError{Message: fmt.Sprintf("exit code %v with invalid response stream '%s'", *codeMapping.ExitCode, codeMapping.ResponseStream), Level: ErrorLevelCritical})
+		}
+	}
+
+	// Check default status code
 	if !slices.ContainsFunc(r.StatusCodes, func(i ExitCodeMapping) bool { return i.ExitCode == nil }) {
-		result = append(result, RouteError{Message: "no default status code defined", Level: ErrorLevelInfo})
+		result = append(result, RouteError{Message: "no default status code for non-zero exit codes defined: uses 500 now", Level: ErrorLevelInfo})
 	}
 
 	// Check query params

--- a/src/common/config/route.go
+++ b/src/common/config/route.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"net/http"
+	"slices"
+	"strings"
 )
 
 const RouteParamPrefix = "WC_"
@@ -9,21 +11,38 @@ const RouteParamPrefix = "WC_"
 var allowedMethods = []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete}
 
 type Route struct {
-	Method      string            // HTTP method
-	Route       string            // Route pattern, includes the url path parameters
-	Headers     map[string]string // Default response headers for this route
-	QueryParams []string          // List of allowed url query parameters
-	StatusCodes []ExitCodeMapping // List of exit-code to status-code mappings
-	Env         map[string]string // Environment variable map
-	AllowBody   bool              // Enable reading the request body and writing it into stdin of the exec environment
-	Exec        RouteExec
+	Method         string            // HTTP method
+	Route          string            // Route pattern, includes the url path parameters
+	Headers        map[string]string // Default response headers for this route
+	QueryParams    []string          // List of allowed url query parameters
+	StatusCodes    []ExitCodeMapping // List of exit-code to status-code mappings
+	Env            map[string]string // Environment variable map
+	AllowBody      bool              // Enable reading the request body and writing it into stdin of the exec environment
+	Exec           RouteExec         // Exec config
+	ResponseStream StdStream         // Default output stream used in response for all exit codes
 }
 
 type ExitCodeMapping struct {
-	ExitCode      *int              // The base exit code from which to map from
-	StatusCode    int               // Status code to map to
-	ResponseEmpty bool              // Send empty response for this exit code
-	Headers       map[string]string // Special response headers for this exit code
+	ExitCode       *int              // The base exit code from which to map from
+	StatusCode     int               // Status code to map to
+	Headers        map[string]string // Special response headers for this exit code
+	ResponseStream StdStream         // Output stream used in response for this exit code
+}
+
+// Stream constants
+type StdStream string
+
+const (
+	StdOut StdStream = "stdout"
+	StdErr StdStream = "stderr"
+	Both   StdStream = "both"
+	None   StdStream = "none"
+)
+
+var allowedStreams = []StdStream{StdOut, StdErr, Both, None}
+
+func (stream StdStream) IsValid() bool {
+	return stream == "" || slices.Contains(allowedStreams, StdStream(strings.ToLower(string(stream))))
 }
 
 // Return a default route configuration that can be used as the base for further configuration.
@@ -36,8 +55,9 @@ func DefaultRoute() Route {
 		StatusCodes: []ExitCodeMapping{
 			{ExitCode: &zero, StatusCode: 200},
 		},
-		Env:         make(map[string]string),
-		QueryParams: make([]string, 0),
+		Env:            make(map[string]string),
+		QueryParams:    make([]string, 0),
+		ResponseStream: Both,
 	}
 }
 

--- a/src/services/chirouter/router.go
+++ b/src/services/chirouter/router.go
@@ -128,9 +128,9 @@ func (r *chirouter) addRoute(route config.Route, executor execution.Executer, lo
 		// Respond with command result and mapped status code from exit code
 		w.WriteHeader(exitResponse.StatusCode)
 		writtenLen := 0
-		if !exitResponse.ResponseEmpty {
-			w.Write(result.StdOutErr.Bytes())
-			writtenLen = len(result.StdOutErr.Bytes())
+		if buffer := exitResponse.ResponseBufferFor(result); buffer != nil {
+			w.Write(buffer.Bytes())
+			writtenLen = len(buffer.Bytes())
 		}
 
 		// Log and finish


### PR DESCRIPTION
Features:
- Available response streams: "none", "stdout", "stderr", "both"
- Define default response stream for route
- Define response stream for specific exit code

Breaking Changes:
- Replaces the "responseEmpty" field with more fine-grained "responseStream"

closes #5