### PR TITLE
fix: rename executer to procexecuter

### DIFF
--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -14,7 +14,7 @@ import (
 	"github.com/bdoerfchen/webcmd/src/logging"
 	"github.com/bdoerfchen/webcmd/src/services/chirouter"
 	"github.com/bdoerfchen/webcmd/src/services/configloader"
-	"github.com/bdoerfchen/webcmd/src/services/executer"
+	"github.com/bdoerfchen/webcmd/src/services/procexecuter"
 	"github.com/bdoerfchen/webcmd/src/services/server"
 	"github.com/bdoerfchen/webcmd/src/services/shellexecuter"
 	"github.com/spf13/cobra"
@@ -108,7 +108,7 @@ func runExec(ctx context.Context) {
 
 	// Setup executers (proc + shell)
 	var executers execution.ExecuterCollection
-	executers.Add(executer.New())          // Normal proc executer
+	executers.Add(procexecuter.New())      // Normal proc executer
 	executers.SetExcept(shellexecuter.New( // Shell executer with pool, except for windows
 		config.Modules.ShellPool.Size,
 		process.Template{

--- a/src/services/procexecuter/executer.go
+++ b/src/services/procexecuter/executer.go
@@ -1,4 +1,4 @@
-package executer
+package procexecuter
 
 import (
 	"context"
@@ -9,13 +9,13 @@ import (
 	"github.com/bdoerfchen/webcmd/src/common/process"
 )
 
-type executer struct{}
+type procExecuter struct{}
 
-func New() *executer {
-	return &executer{}
+func New() *procExecuter {
+	return &procExecuter{}
 }
 
-func (e *executer) Execute(ctx context.Context, config execution.Config) (proc *process.Process, exitCode int, err error) {
+func (e *procExecuter) Execute(ctx context.Context, config execution.Config) (proc *process.Process, exitCode int, err error) {
 	// Prepare new command
 	cmd, err := process.Prepare(&process.Template{
 		Command:   config.Command,
@@ -47,6 +47,6 @@ func (e *executer) Execute(ctx context.Context, config execution.Config) (proc *
 	return cmd, 0, nil
 }
 
-func (e *executer) Describe() (mode execution.ExecMode, attributes []any) {
+func (e *procExecuter) Describe() (mode execution.ExecMode, attributes []any) {
 	return execution.ModeProc, []any{}
 }


### PR DESCRIPTION
Fixes:
- Renamed executer package to procexecuter
- Renamed executer struct to procExecuter

Now this package better fits into the general executer landscape, as it is not the only executer anymore. The shellexecuter was called like this since its introduction, but renaming the base one was not done there in #16.